### PR TITLE
Feature: Inline Forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## [Unreleased] -->
 
+## [3.1.2] - 2023-08-10
+
+- Add support for [inline forms](https://swup.js.org/plugins/forms-plugin/#inline-forms)
+
 ## [3.1.1] - 2023-08-09
 
 - Fix toplevel `"types"` export
@@ -36,8 +40,9 @@
 
 - Initial release
 
-[Unreleased]: https://github.com/swup/forms-plugin/compare/3.1.1...HEAD
+[Unreleased]: https://github.com/swup/forms-plugin/compare/3.1.2...HEAD
 
+[3.1.2]: https://github.com/swup/forms-plugin/releases/tag/3.1.2
 [3.1.1]: https://github.com/swup/forms-plugin/releases/tag/3.1.1
 [3.1.0]: https://github.com/swup/forms-plugin/releases/tag/3.1.0
 [3.0.0]: https://github.com/swup/forms-plugin/releases/tag/3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- ## [Unreleased] -->
 
-## [3.1.2] - 2023-08-10
+## [3.2.2] - 2023-08-10
 
 - Add support for [inline forms](https://swup.js.org/plugins/forms-plugin/#inline-forms)
 
@@ -40,9 +40,9 @@
 
 - Initial release
 
-[Unreleased]: https://github.com/swup/forms-plugin/compare/3.1.2...HEAD
+[Unreleased]: https://github.com/swup/forms-plugin/compare/3.2.2...HEAD
 
-[3.1.2]: https://github.com/swup/forms-plugin/releases/tag/3.1.2
+[3.2.2]: https://github.com/swup/forms-plugin/releases/tag/3.2.2
 [3.1.1]: https://github.com/swup/forms-plugin/releases/tag/3.1.1
 [3.1.0]: https://github.com/swup/forms-plugin/releases/tag/3.1.0
 [3.0.0]: https://github.com/swup/forms-plugin/releases/tag/3.0.0

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ If you give a form an additional attribute `[data-swup-inline-form]`, swup will:
 
 **HTML**
 ```html
-<form id="form-1" data-swup-form data-swup-inline-form method="POST">
+<form id="form-1" class="transition-form" data-swup-form data-swup-inline-form method="POST">
   <input name="test"></input> <input type="submit"></input>
 </form>
 ```
 **CSS**
 ```css
-#form-1.is-changing {
+.transition-form.is-changing {
   transition: opacity 200ms;
 }
-#form-1.is-animating {
+.transition-form.is-animating {
   opacity: 0;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ new SwupFormsPlugin({
 });
 ```
 
+## Inline Forms
+
+If you give a form an additional attribute `[data-swup-inline-form]`, swup will:
+
+- update only that form when being submitted, ignoring the default `containers`.
+- scroll back to the beginning of the form
+- scope animations to the form itself
+
+> **Note** If you mark a form as an inline form, the form **must have an `id` attribute**
+
+### Example
+
+**HTML**
+```html
+<form id="form-1" data-swup-form data-swup-inline-form method="POST">
+  <input name="test"></input> <input type="submit"></input>
+</form>
+```
+**CSS**
+```css
+#form-1.is-changing {
+  transition: opacity 200ms;
+}
+#form-1.is-animating {
+  opacity: 0;
+}
+```
+
 ## Hooks
 
 The plugin adds two new hooks to swup.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Plugin from '@swup/plugin';
 import { Location, getCurrentUrl } from 'swup';
-import type { DelegateEvent, DelegateEventUnsubscribe } from 'swup';
+import type { DelegateEvent, DelegateEventUnsubscribe, Handler } from 'swup';
 
 declare module 'swup' {
 	export interface HookDefinitions {
@@ -62,6 +62,8 @@ export default class SwupFormsPlugin extends Plugin {
 				capture: true
 			}
 		);
+
+		this.on('visit:start', this.handleInlineForms, { priority: 1 });
 
 		document.addEventListener('keydown', this.onKeyDown);
 		document.addEventListener('keyup', this.onKeyUp);
@@ -224,5 +226,24 @@ export default class SwupFormsPlugin extends Plugin {
 		if (this.specialKeys.hasOwnProperty(event.key)) {
 			this.specialKeys[event.key] = false;
 		}
+	};
+
+	/**
+	 * Handles visits triggered by forms matching [data-swup-inline-form]
+	 */
+	handleInlineForms: Handler<'visit:start'> = (visit) => {
+		const { el } = visit.trigger;
+		if (!el?.matches('form[data-swup-inline-form]')) return;
+
+		if (!el.id) {
+			console.error(`[@swup/forms-plugin] inline forms must have an id attribute:`, el);
+			return;
+		}
+
+		const selector = `#${el.id}`;
+		visit.containers = [selector];
+		visit.animation.scope = 'containers';
+		visit.animation.selector = selector;
+		visit.scroll.target = selector;
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ type DelegatedSubmitEvent = DelegateEvent<SubmitEvent, HTMLFormElement>;
 
 type Options = {
 	formSelector: string;
+	inlineFormSelector: string;
 };
 
 type FormInfo = {
@@ -30,7 +31,8 @@ export default class SwupFormsPlugin extends Plugin {
 	requires = { swup: '>=4' };
 
 	defaults: Options = {
-		formSelector: 'form[data-swup-form]'
+		formSelector: 'form[data-swup-form]',
+		inlineFormSelector: 'form[data-swup-inline-form]'
 	};
 	options: Options;
 
@@ -233,7 +235,7 @@ export default class SwupFormsPlugin extends Plugin {
 	 */
 	handleInlineForms: Handler<'visit:start'> = (visit) => {
 		const { el } = visit.trigger;
-		if (!el?.matches('form[data-swup-inline-form]')) return;
+		if (!el?.matches(this.options.inlineFormSelector)) return;
 
 		if (!el.id) {
 			console.error(`[@swup/forms-plugin] inline forms must have an id attribute:`, el);


### PR DESCRIPTION
**Description**

Allows to mark forms as inline forms, based on https://github.com/orgs/swup/discussions/761. This:

```html
<form id="form-1" data-swup-form data-swup-inline-form method="POST">
  <input name="test"></input> <input type="submit"></input>
</form>
```
...will:

- update only that form when being submitted, ignoring the default `containers`.
- scroll back to the beginning of the form
- scope animations to the form itself

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

