### PR TITLE
Allow overrides from submitter element

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A [swup](https://swup.js.org) plugin for submitting forms.
 - Opt-in with a configurable selector, by default `form[data-swup-form]`
 - Respects custom animations set on the form element
 
-**Note:** This plugin is perfect for simple scenarios like search or
-contact forms. For complex requirements like file uploads or custom
+**Note:** This plugin is meant for simple scenarios like search or
+contact forms. For complex requirements like custom
 serialization, it is recommended to use the swup API directly.
 
 ## Installation

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ export default class SwupFormsPlugin extends Plugin {
 	/**
 	 * Get information about where and how a form will submit
 	 */
-	protected getFormInfo(form: HTMLFormElement, { submitter }: SubmitEvent): FormInfo {
+	getFormInfo(form: HTMLFormElement, { submitter }: SubmitEvent): FormInfo {
 		const method = (this.getFormAttr('method', form, submitter) || 'get').toUpperCase() as 'GET' | 'POST';
 		const action = this.getFormAttr('action', form, submitter) || getCurrentUrl();
 		const { url, hash } = Location.fromUrl(action);

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,13 @@ export default class SwupFormsPlugin extends Plugin {
 	}
 
 	/**
+	 * Get a form attribute either from the form, or the submitter element if present
+	 */
+	getFormAttr(attr: string, form: HTMLFormElement, submitter: HTMLElement | null = null): string | null{
+		return submitter?.getAttribute(`form${attr}`) ?? form.getAttribute(attr);
+	}
+
+	/**
 	 * Appends query parameters to a URL
 	 */
 	appendQueryParams(url: string, data: FormData): string {


### PR DESCRIPTION
**Description**

Allow [overriding form behavior](https://developer.mozilla.org/en-US/docs/Glossary/Submit_button#overriding_the_forms_behavior) like action, method and target from the submit button that was clicked:

```html
<form action="/" method="POST">
  <input type="submit" formmethod="GET" value="Submit as GET">
  <input type="submit" formaction="/search" value="Submit to /search">
</form>
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #54 