### PR TITLE
Fix consecutive submissions by creating temporary visit object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8200,9 +8200,9 @@
       }
     },
     "node_modules/swup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/swup/-/swup-4.4.0.tgz",
-      "integrity": "sha512-cBWO0jNmorODe/CBkQ9tH708fsMckCcaIOlWz+uc0GQfH2Db8Io9C+fr/s1QcMlWrI6+FwLHHNyL3us3sCP2Zg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/swup/-/swup-4.5.2.tgz",
+      "integrity": "sha512-G8BCYwQutc52vP8xyrWtfi6tQch0+85Ur0aSgjJItwLu8XWPiyuqPmhEKSx1JtdDQxjnh7Z/yFn1t4P6tqs0yw==",
       "hasInstallScript": true,
       "dependencies": {
         "delegate-it": "^6.0.0",


### PR DESCRIPTION
**Description**

- Fix #63
- Confirmed as fixed on example site

**How does it fix the issue?**

- The forms plugin hasn't yet switched to [creating a temporary visit object](https://github.com/swup/swup/blob/master/src/Swup.ts#L278) for pre-navigation hooks like `link:click`
- This will make swup fall back to the global `this.visit` object inside the handlers
- After the first successful submission, `this.visit` has been marked as `done`
- In the second submission, swup will consider the current visit done (= aborted) and silently drop the hook handler
- This fixes it by creating a temporary visit object with url, hash, element and event, before calling `form:submit`
- Since the temporary visit isn't marked `done`, it will not be dropped by swup

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

Fixes #63 