### PR TITLE
feat: strip empty params

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ swup. By default, any form with a `data-swup-form` attribute is selected.
 
 Customize the selector for [inline forms](#inline-forms)
 
+### stripEmptyParams
+
+Strip empty parameters from forms with `action="GET"` before submitting. Cleans up the resulting URL.
+
+Before: `?foo=&bar=baz`
+
+After: `?bar=baz`
+
 ### Default Options
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -84,27 +84,33 @@ If you give a form an additional attribute `[data-swup-inline-form]`, swup will:
 
 ### formSelector
 
+Type: `String`, Default: `form[data-swup-form]`
+
 The `formSelector` option defines a selector for forms which should be sent via
 swup. By default, any form with a `data-swup-form` attribute is selected.
 
 ### inlineFormSelector
 
+Type: `String`, Default: `form[data-swup-inline-form]`
+
 Customize the selector for [inline forms](#inline-forms)
 
 ### stripEmptyParams
 
-Strip empty parameters from forms with `action="GET"` before submitting. Cleans up the resulting URL.
+Type: `Boolean`, Default: `false`
 
-Before: `?foo=&bar=baz`
+Strip empty parameters from forms with `action="GET"` before submitting.
 
-After: `?bar=baz`
+- Before: `?foo=&bar=baz&bat=`
+- After: `?bar=baz`
 
 ### Default Options
 
 ```javascript
 new SwupFormsPlugin({
   formSelector: 'form[data-swup-form]',
-  inlineFormSelector: 'form[data-swup-inline-form]'
+  inlineFormSelector: 'form[data-swup-inline-form]',
+  stripEmptyParams: false
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,16 +104,6 @@ Strip empty parameters from forms with `action="GET"` before submitting.
 - Before: `?foo=&bar=baz&bat=`
 - After: `?bar=baz`
 
-### Default Options
-
-```javascript
-new SwupFormsPlugin({
-  formSelector: 'form[data-swup-form]',
-  inlineFormSelector: 'form[data-swup-inline-form]',
-  stripEmptyParams: false
-});
-```
-
 ## Hooks
 
 The plugin adds two new hooks to swup.

--- a/README.md
+++ b/README.md
@@ -82,20 +82,19 @@ If you give a form an additional attribute `[data-swup-inline-form]`, swup will:
 
 ## Options
 
-### formSelector
+### `formSelector`
 
 Type: `String`, Default: `form[data-swup-form]`
 
-The `formSelector` option defines a selector for forms which should be sent via
-swup. By default, any form with a `data-swup-form` attribute is selected.
+Customize the selector for forms which should be handled by swup.
 
-### inlineFormSelector
+### `inlineFormSelector`
 
 Type: `String`, Default: `form[data-swup-inline-form]`
 
 Customize the selector for [inline forms](#inline-forms)
 
-### stripEmptyParams
+### `stripEmptyParams`
 
 Type: `Boolean`, Default: `false`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export default class SwupFormsPlugin extends Plugin {
 		if (!this.options.stripEmptyParams) return;
 
 		for (const [name, value] of Array.from(data.entries())) {
-			if (typeof value === 'string' && value.trim() === '') data.delete(name);
+			if (value === '') data.delete(name);
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ type DelegatedSubmitEvent = DelegateEvent<SubmitEvent, HTMLFormElement>;
 type Options = {
 	formSelector: string;
 	inlineFormSelector: string;
-  stripEmptyParams: boolean;
+	stripEmptyParams: boolean;
 };
 
 type FormInfo = {
@@ -34,7 +34,7 @@ export default class SwupFormsPlugin extends Plugin {
 	defaults: Options = {
 		formSelector: 'form[data-swup-form]',
 		inlineFormSelector: 'form[data-swup-inline-form]',
-    stripEmptyParams: false
+		stripEmptyParams: false
 	};
 	options: Options;
 
@@ -88,7 +88,8 @@ export default class SwupFormsPlugin extends Plugin {
 		const { delegateTarget: form, submitter } = event;
 		const action = this.getFormAttr('action', form, submitter) || getCurrentUrl();
 		const opensInNewTabFromKeyPress = this.isSpecialKeyPressed();
-		const opensInNewTabFromTargetAttr = this.getFormAttr('target', form, submitter) === '_blank';
+		const opensInNewTabFromTargetAttr =
+			this.getFormAttr('target', form, submitter) === '_blank';
 		const opensInNewTab = opensInNewTabFromKeyPress || opensInNewTabFromTargetAttr;
 
 		// Create temporary visit object for form:submit:* hooks
@@ -163,7 +164,7 @@ export default class SwupFormsPlugin extends Plugin {
 				params = { method, body };
 				break;
 			case 'GET':
-        this.maybeStripEmptyParams(data);
+				this.maybeStripEmptyParams(data);
 				action = this.appendQueryParams(action, data);
 				break;
 			default:
@@ -180,7 +181,9 @@ export default class SwupFormsPlugin extends Plugin {
 	 * Get information about where and how a form will submit
 	 */
 	getFormInfo(form: HTMLFormElement, { submitter }: SubmitEvent): FormInfo {
-		const method = (this.getFormAttr('method', form, submitter) || 'get').toUpperCase() as 'GET' | 'POST';
+		const method = (this.getFormAttr('method', form, submitter) || 'get').toUpperCase() as
+			| 'GET'
+			| 'POST';
 		const action = this.getFormAttr('action', form, submitter) || getCurrentUrl();
 		const { url, hash } = Location.fromUrl(action);
 		const encoding = (
@@ -202,7 +205,11 @@ export default class SwupFormsPlugin extends Plugin {
 	/**
 	 * Get a form attribute either from the form, or the submitter element if present
 	 */
-	getFormAttr(attr: string, form: HTMLFormElement, submitter: HTMLElement | null = null): string | null{
+	getFormAttr(
+		attr: string,
+		form: HTMLFormElement,
+		submitter: HTMLElement | null = null
+	): string | null {
 		return submitter?.getAttribute(`form${attr}`) ?? form.getAttribute(attr);
 	}
 
@@ -215,16 +222,16 @@ export default class SwupFormsPlugin extends Plugin {
 		return query ? `${path}?${query}` : path;
 	}
 
-  /**
-   * Strip empty params from the FormData (by reference)
-   * @see https://stackoverflow.com/a/64029534/586823
-   */
-  maybeStripEmptyParams(data: FormData): void {
-    if (!this.options.stripEmptyParams) return;
-    for (const [name, value] of Array.from(data.entries())) {
-      if (typeof value === 'string' && value.trim() === '') data.delete(name);
-    }
-  }
+	/**
+	 * Strip empty params from the FormData (by reference)
+	 * @see https://stackoverflow.com/a/64029534/586823
+	 */
+	maybeStripEmptyParams(data: FormData): void {
+		if (!this.options.stripEmptyParams) return;
+		for (const [name, value] of Array.from(data.entries())) {
+			if (typeof value === 'string' && value.trim() === '') data.delete(name);
+		}
+	}
 
 	/**
 	 * Is either command or control key down at the moment

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,7 @@ export default class SwupFormsPlugin extends Plugin {
 	 */
 	maybeStripEmptyParams(data: FormData): void {
 		if (!this.options.stripEmptyParams) return;
+
 		for (const [name, value] of Array.from(data.entries())) {
 			if (typeof value === 'string' && value.trim() === '') data.delete(name);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ type DelegatedSubmitEvent = DelegateEvent<SubmitEvent, HTMLFormElement>;
 type Options = {
 	formSelector: string;
 	inlineFormSelector: string;
+  stripEmptyParams: boolean;
 };
 
 type FormInfo = {
@@ -32,7 +33,8 @@ export default class SwupFormsPlugin extends Plugin {
 
 	defaults: Options = {
 		formSelector: 'form[data-swup-form]',
-		inlineFormSelector: 'form[data-swup-inline-form]'
+		inlineFormSelector: 'form[data-swup-inline-form]',
+    stripEmptyParams: false
 	};
 	options: Options;
 
@@ -161,6 +163,7 @@ export default class SwupFormsPlugin extends Plugin {
 				params = { method, body };
 				break;
 			case 'GET':
+        this.maybeStripEmptyParams(data);
 				action = this.appendQueryParams(action, data);
 				break;
 			default:
@@ -211,6 +214,17 @@ export default class SwupFormsPlugin extends Plugin {
 		const query = new URLSearchParams(data as unknown as Record<string, string>).toString();
 		return query ? `${path}?${query}` : path;
 	}
+
+  /**
+   * Strip empty params from the FormData (by reference)
+   * @see https://stackoverflow.com/a/64029534/586823
+   */
+  maybeStripEmptyParams(data: FormData): void {
+    if (!this.options.stripEmptyParams) return;
+    for (const [name, value] of Array.from(data.entries())) {
+      if (typeof value === 'string' && value.trim() === '') data.delete(name);
+    }
+  }
 
 	/**
 	 * Is either command or control key down at the moment


### PR DESCRIPTION
Closes #66 

**Description**

Add new option `stripEmptyParams` that removes empty parameters from forms with a `GET` method.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

**Drive-By**

Add type and default information to [all options](https://github.com/swup/forms-plugin/tree/feat/strip-empty-params?tab=readme-ov-file#options)